### PR TITLE
Add option to disable hooks

### DIFF
--- a/publishable/config/hooks.php
+++ b/publishable/config/hooks.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+	'enabled' => env('HOOKS_ENABLED', true),
+
+];

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Larapack\Hooks\Composer;
 use Larapack\Hooks\Events\Setup;
+use Larapack\Hooks\HooksServiceProvider;
 
 class SetupCommand extends Command
 {
@@ -43,6 +44,8 @@ class SetupCommand extends Command
         }
 
         $composer->save();
+
+        $this->call('vendor:publish', ['--provider' => HooksServiceProvider::class]);
 
         $this->info('Hooks are now ready to use! Go ahead and try to "php artisan hook:install test-hook"');
 

--- a/src/HooksServiceProvider.php
+++ b/src/HooksServiceProvider.php
@@ -12,9 +12,22 @@ class HooksServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $configPath = dirname(__DIR__) . '/publishable/config/hooks.php';
+
+        $this->mergeConfigFrom($configPath, 'hooks');
+
+        if (!config('hooks.enabled', true)) {
+            return;
+        }
+
         // Registers resources and commands
         if ($this->app->runningInConsole()) {
             $this->registerCommands();
+
+            $this->publishes(
+                [$configPath => config_path('hooks.php')],
+                'hooks-config'
+            );
         }
 
         // Register Hooks system and aliases
@@ -49,6 +62,10 @@ class HooksServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if (!config('hooks.enabled', true)) {
+            return;
+        }
+
         // Register hook providers
         $this->registerHookProviders();
     }


### PR DESCRIPTION
Setting `enabled` to `false` will not run any hooks or any hook related commands.